### PR TITLE
added copyright info and removed unnecessary config requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ Example Config file:
 - Primary key column(s): AmazonOrderId
 - Replicated fully
 - Link to API endpoint documentation: http://docs.developer.amazonservices.com/en_US/orders-2013-09-01/Orders_ListOrderItems.html
+
+
+---
+
+Copyright &copy; 2019 Stitch

--- a/tap_mws/__init__.py
+++ b/tap_mws/__init__.py
@@ -21,7 +21,7 @@ def main():
     """
     args = singer.utils.parse_args(
         required_config_keys=['seller_id', 'aws_access_key',
-                              'client_secret', 'marketplace_id', 'start_date', 'user_agent']
+                              'client_secret', 'marketplace_id', 'start_date']
     )
 
     # When writing out the bookmark/state, it adds an extra 'level' to the


### PR DESCRIPTION
# Description of change
Added copyright to readme and removed an unnecessary config key, 'user_agent'

# Manual QA steps
 - none
 
# Risks
 - If that config key is needed later on, that could be an issue. Currently, there is no other place in the repo where that key is used.
 
# Rollback steps
 - revert this branch
